### PR TITLE
chore: add simple stop command

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
 		"Other"
 	],
 	"activationEvents": [
-		"onCommand:camelk.runfile"
+		"onCommand:camelk.runfile",
+		"onCommand:camelk.stopfile"
 	],
 	"main": "./out/extension",
 	"contributes": {
@@ -19,12 +20,21 @@
 			{
 				"command": "camelk.runfile",
 				"title": "Run file with Camel-K"
+			},
+			{
+				"command": "camelk.stopfile",
+				"title": "Stop Camel-K integration"
 			}
 		],
 		"menus": {
 			"explorer/context": [
 				{
 					"command": "camelk.runfile",
+					"when": "resourceExtname == .groovy",
+					"group": "navigation"
+				},
+				{
+					"command": "camelk.stopfile",
 					"when": "resourceExtname == .groovy",
 					"group": "navigation"
 				}


### PR DESCRIPTION
The child process handle is stored in the workspace state (might not be so safe between editor restarts), so when run with `kamel --dev` sending `CTRL+C` (`SIGINT`) will stop/delete the running kamel integration.

Otherwise if the kamel integration is run outside of the workspace it will be stopped/deleted via `kamel delete`.

Super POCy :)